### PR TITLE
Exclude country flags from being shown in the top banner

### DIFF
--- a/src/home.js
+++ b/src/home.js
@@ -6,7 +6,7 @@ $(document).ready(function() {
 	// get all emojis and generate category showcase
 	$.getJSON( "data/openmoji.json" , function(json) {
 		EMOJI_LIST = json.filter(function(emoji) {
-			return emoji.skintone === "";
+			return emoji.skintone === "" && emoji.subgroups != "country-flag";
 		});
 
 		genEmojiCloud();


### PR DESCRIPTION
Currently, when opening the page the header shows a fair amount of country flags alongside emojis. However, I feel like they sort of overtake the other emojis in their prominence, that's why I propose excluding them from the top banner with this PR.